### PR TITLE
Fix ReflectionTypeLoadException

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Copyright>Copyright © tom-englert.de 2019-2021. Distributed under the MIT License.</Copyright>
     <Product>SplashScreen.Fody</Product>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
     <Description>Lets you design your WPF splash screen as a WPF Control instead of a static bitmap</Description>
     <WeaverTargetFramework>netstandard2.0</WeaverTargetFramework>
     <WeaverNugetFolder>netstandardweaver</WeaverNugetFolder>


### PR DESCRIPTION
I implemented a really small change to handle `ReflectionTypeLoadException`s better. Under certain circumstances, that I think are not that uncommon, using `GetTypes` to reflect all types from the assembly fails with said exception, leading to any project using **SplashScreen.Fody** not getting a splash screen due to not even build anymore. To prevent this and at least get the types that could be reflected, the change was necessary.

I considered adding a property to the **SplashScreen** weaver setup inside the _FodyWeavers.xml_, that would allow to specify the name of the splash screen class upfront but didn't now how to accomplish this. Basically, something like `<SplashScreen TypeName="MySplashScreen" />`. Somehow this should become a parameter `splashScreenTypeName` for the `Program.GenerateBase64EncodedBitmap` function ultimately leading to first only reflect this type from the assembly directly via `targetAssembly.GetType(splashScreenTypeName)` and only afterwards using `targetAssembly.GetTypes()` as fallback. This approach would also help in regard of the `ReflectionTypeLoadException` and additionally speed up the process of creating the splash screen a little bit.

Furthermore I was unable add any kind of unit test to the existing test structure, as I don't understand how it works. It doesn't even seem to contain any test whatsoever. Nonetheless I hope you consider pulling my changes into your project. Please be aware, that I already bumped the version to **2.0.5**, so I could use the modified version in my projects.